### PR TITLE
Add web server to serve index.html on port 3000

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,31 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = 3000;
+
+const server = http.createServer((req, res) => {
+  // Handle root path and serve index.html
+  if (req.url === '/' || req.url === '/index.html') {
+    const filePath = path.join(__dirname, 'index.html');
+    
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal Server Error');
+        return;
+      }
+      
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(data);
+    });
+  } else {
+    // Handle 404 for other paths
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not Found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}/`);
+});


### PR DESCRIPTION
## Summary
• Implements a Node.js web server that serves the index.html file on port 3000
• Handles root path and /index.html requests with proper error handling for 404s

## Test plan
- [ ] Run `node server.js` to start the server
- [ ] Verify server starts on port 3000
- [ ] Test accessing http://localhost:3000/ serves index.html
- [ ] Test accessing http://localhost:3000/index.html serves index.html
- [ ] Test accessing non-existent paths returns 404

🤖 Generated with [Claude Code](https://claude.ai/code)